### PR TITLE
feat: Return manifest digest from push operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.6.0 - 2026-01-02
+
+### Breaking Changes
+
+- **Push functions now return digest**: `ocibuild:push/3,4,5` and `ocibuild:push_multi/4,5` now return `{ok, Digest}` instead of `ok` on success. This enables CI/CD integration with attestation workflows (e.g., `actions/attest-build-provenance`).
+  - Before: `ok = ocibuild:push(Image, Registry, RepoTag)`
+  - After: `{ok, Digest} = ocibuild:push(Image, Registry, RepoTag)`
+
+### Features
+
+- **Digest output after push**: After a successful push, the full image reference with digest is printed to stdout:
+  ```
+  Pushed: ghcr.io/org/repo:tag@sha256:abc123...
+  ```
+  This format is machine-parseable for CI/CD pipelines that need the digest for signing, attestation, or verification.
+
 ## 0.5.1 - 2025-12-29
 
 ### Bugfixes

--- a/src/ocibuild.app.src
+++ b/src/ocibuild.app.src
@@ -1,6 +1,6 @@
 {application, ocibuild, [
     {description, "Build and publish OCI container images from the BEAM"},
-    {vsn, "0.5.1"},
+    {vsn, "0.6.0"},
     {registered, []},
     {applications, [kernel, stdlib, crypto, ssl, inets]},
     {env, []},

--- a/src/ocibuild.erl
+++ b/src/ocibuild.erl
@@ -417,10 +417,13 @@ user(#{config := Config} = Image, User) when is_binary(User) ->
 Push the image to a container registry.
 
 ```
-ok = ocibuild:push(Image, ~"ghcr.io", ~"myorg/myapp:v1.0.0").
+{ok, Digest} = ocibuild:push(Image, ~"ghcr.io", ~"myorg/myapp:v1.0.0").
 ```
+
+Returns `{ok, Digest}` where Digest is the sha256 digest of the pushed manifest.
 """.
--spec push(image(), Registry :: binary(), RepoTag :: binary()) -> ok | {error, term()}.
+-spec push(image(), Registry :: binary(), RepoTag :: binary()) ->
+    {ok, Digest :: binary()} | {error, term()}.
 push(Image, Registry, RepoTag) ->
     push(Image, Registry, RepoTag, #{}).
 
@@ -430,11 +433,13 @@ Push the image to a container registry with authentication.
 ```
 %% GHCR uses username + token as password
 Auth = #{username => ~"github-user", password => ~"github-token"},
-ok = ocibuild:push(Image, ~"ghcr.io", ~"myorg/myapp:v1.0.0", Auth).
+{ok, Digest} = ocibuild:push(Image, ~"ghcr.io", ~"myorg/myapp:v1.0.0", Auth).
 ```
+
+Returns `{ok, Digest}` where Digest is the sha256 digest of the pushed manifest.
 """.
 -spec push(image(), Registry :: binary(), RepoTag :: binary(), auth()) ->
-    ok | {error, term()}.
+    {ok, Digest :: binary()} | {error, term()}.
 push(Image, Registry, RepoTag, Auth) ->
     push(Image, Registry, RepoTag, Auth, #{}).
 
@@ -450,11 +455,13 @@ Example:
 ```
 Auth = #{username => ~"user", password => ~"pass"},
 Opts = #{chunk_size => 10 * 1024 * 1024},  % 10MB chunks
-ok = ocibuild:push(Image, ~"ghcr.io", ~"myorg/myapp:v1", Auth, Opts).
+{ok, Digest} = ocibuild:push(Image, ~"ghcr.io", ~"myorg/myapp:v1", Auth, Opts).
 ```
+
+Returns `{ok, Digest}` where Digest is the sha256 digest of the pushed manifest.
 """.
 -spec push(image(), Registry :: binary(), RepoTag :: binary(), auth(), map()) ->
-    ok | {error, term()}.
+    {ok, Digest :: binary()} | {error, term()}.
 push(Image, Registry, RepoTag, Auth, Opts) ->
     {Repo, Tag} = parse_repo_tag(RepoTag),
     ocibuild_registry:push(Image, Registry, Repo, Tag, Auth, Opts).
@@ -478,17 +485,23 @@ Example:
 Images2 = [ocibuild:copy(I, Files, ~"/app") || I <- Images],
 %% Push as multi-platform image
 Auth = #{username => ~"user", password => ~"pass"},
-ok = ocibuild:push_multi(Images2, ~"ghcr.io", ~"myorg/myapp:v1", Auth).
+{ok, Digest} = ocibuild:push_multi(Images2, ~"ghcr.io", ~"myorg/myapp:v1", Auth).
 ```
+
+Returns `{ok, Digest}` where Digest is the sha256 digest of the pushed image index.
 """.
 -spec push_multi([image()], Registry :: binary(), RepoTag :: binary(), auth()) ->
-    ok | {error, term()}.
+    {ok, Digest :: binary()} | {error, term()}.
 push_multi(Images, Registry, RepoTag, Auth) ->
     push_multi(Images, Registry, RepoTag, Auth, #{}).
 
--doc "Push multiple images as a multi-platform image with options.".
+-doc """
+Push multiple images as a multi-platform image with options.
+
+Returns `{ok, Digest}` where Digest is the sha256 digest of the pushed image index.
+""".
 -spec push_multi([image()], Registry :: binary(), RepoTag :: binary(), auth(), map()) ->
-    ok | {error, term()}.
+    {ok, Digest :: binary()} | {error, term()}.
 push_multi(Images, Registry, RepoTag, Auth, Opts) ->
     {Repo, Tag} = parse_repo_tag(RepoTag),
     ocibuild_registry:push_multi(Images, Registry, Repo, Tag, Auth, Opts).


### PR DESCRIPTION
Breaking change: `ocibuild:push/3,4,5` and `ocibuild:push_multi/4,5` now return `{ok, Digest}` instead of `ok` on success. The digest is also printed to stdout in the format `Pushed: registry/repo:tag@sha256:...` to enable CI/CD integration with attestation workflows.