### PR TITLE
ci(docs): pin upload-pages-artifact transitive dependency

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -45,7 +45,7 @@ jobs:
         run: rebar3 ex_doc
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: doc
 


### PR DESCRIPTION
## Summary

- Upgrades `actions/upload-pages-artifact` from v3.0.1 to v5.0.0
- v3.0.1 internally references `actions/upload-artifact@v4` (a tag, not a SHA), which violates the org policy requiring all actions to be pinned to full-length commit SHAs
- v5.0.0 pins its internal `upload-artifact` reference at a SHA (`@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0`)

## Test plan

- [ ] Verify the docs workflow passes on this PR's CI run