### PR TITLE
fix(http): kill orphaned httpc processes instead of stopping SSL

### DIFF
--- a/src/http/ocibuild_registry.erl
+++ b/src/http/ocibuild_registry.erl
@@ -2408,8 +2408,32 @@ stop_httpc() ->
                 ok
             end
     end,
-    _ = ssl:stop(),
+    %% Kill any orphaned httpc processes registered with our naming convention
+    %% (httpc_ocibuild_*). Workers start standalone httpc via inets:start/3 with
+    %% stand_alone mode, which places them outside any OTP application supervision
+    %% tree. Normally workers link to their httpc and both die together, but a
+    %% race between supervisor shutdown and worker cleanup can leave httpc alive.
+    %% On OTP 28+, init:stop() waits for ALL processes to terminate, so any
+    %% surviving standalone httpc will block VM shutdown indefinitely.
+    cleanup_orphaned_httpc(),
     ok.
+
+-spec cleanup_orphaned_httpc() -> ok.
+cleanup_orphaned_httpc() ->
+    Prefix = "httpc_ocibuild_",
+    Orphans = [N || N <- registered(), lists:prefix(Prefix, atom_to_list(N))],
+    lists:foreach(fun kill_registered/1, Orphans).
+
+-spec kill_registered(atom()) -> ok.
+kill_registered(Name) ->
+    case whereis(Name) of
+        Pid when is_pid(Pid) ->
+            _ = (catch unregister(Name)),
+            exit(Pid, kill),
+            ok;
+        undefined ->
+            ok
+    end.
 
 %% Get SSL options for HTTPS requests
 -spec ssl_opts() -> [ssl:tls_client_option()].

--- a/src/http/ocibuild_registry.erl
+++ b/src/http/ocibuild_registry.erl
@@ -2428,8 +2428,8 @@ cleanup_orphaned_httpc() ->
 kill_registered(Name) ->
     case whereis(Name) of
         Pid when is_pid(Pid) ->
-            _ = (catch unregister(Name)),
-            exit(Pid, kill),
+            catch unregister(Name),
+            catch exit(Pid, kill),
             ok;
         undefined ->
             ok

--- a/test/http/ocibuild_shutdown_tests.erl
+++ b/test/http/ocibuild_shutdown_tests.erl
@@ -31,11 +31,17 @@ stop_is_idempotent_test() ->
 %%% Tests for ocibuild_registry:stop_httpc/0
 %%%===================================================================
 
-stop_httpc_stops_ssl_test() ->
+stop_httpc_does_not_stop_ssl_test() ->
+    %% stop_httpc must NOT stop SSL or its dependencies (crypto, asn1, public_key).
+    %% Stopping applications is unsafe when ocibuild is used as a library inside
+    %% another app that depends on them.
     ssl:start(),
-    ?assertMatch({ok, _}, application:ensure_all_started(ssl)),
     ocibuild_registry:stop_httpc(),
-    ?assertEqual({error, {not_started, ssl}}, ssl:stop()).
+    %% SSL should still be running
+    ?assert(lists:keymember(ssl, 1, application:which_applications())),
+    ?assert(lists:keymember(crypto, 1, application:which_applications())),
+    %% Clean up for other tests
+    ssl:stop().
 
 stop_httpc_when_nothing_running_test() ->
     ?assertEqual(ok, ocibuild_registry:stop_httpc()).
@@ -45,3 +51,18 @@ stop_httpc_stops_supervisor_test() ->
     ?assertNotEqual(undefined, whereis(ocibuild_http_sup)),
     ocibuild_registry:stop_httpc(),
     ?assertEqual(undefined, whereis(ocibuild_http_sup)).
+
+stop_httpc_kills_orphaned_processes_test() ->
+    %% Simulate orphaned httpc processes (e.g., from a crashed worker)
+    Orphan1 = spawn(fun() -> receive stop -> ok end end),
+    register(httpc_ocibuild_orphan1, Orphan1),
+    Orphan2 = spawn(fun() -> receive stop -> ok end end),
+    register(httpc_ocibuild_orphan2, Orphan2),
+    ?assert(is_process_alive(Orphan1)),
+    ?assert(is_process_alive(Orphan2)),
+    ocibuild_registry:stop_httpc(),
+    timer:sleep(10),
+    ?assertNot(is_process_alive(Orphan1)),
+    ?assertNot(is_process_alive(Orphan2)),
+    ?assertEqual(undefined, whereis(httpc_ocibuild_orphan1)),
+    ?assertEqual(undefined, whereis(httpc_ocibuild_orphan2)).

--- a/test/http/ocibuild_shutdown_tests.erl
+++ b/test/http/ocibuild_shutdown_tests.erl
@@ -35,13 +35,17 @@ stop_httpc_does_not_stop_ssl_test() ->
     %% stop_httpc must NOT stop SSL or its dependencies (crypto, asn1, public_key).
     %% Stopping applications is unsafe when ocibuild is used as a library inside
     %% another app that depends on them.
+    WasRunning = lists:keymember(ssl, 1, application:which_applications()),
     ssl:start(),
     ocibuild_registry:stop_httpc(),
     %% SSL should still be running
     ?assert(lists:keymember(ssl, 1, application:which_applications())),
     ?assert(lists:keymember(crypto, 1, application:which_applications())),
-    %% Clean up for other tests
-    ssl:stop().
+    %% Only stop SSL if we started it
+    case WasRunning of
+        true -> ok;
+        false -> ssl:stop()
+    end.
 
 stop_httpc_when_nothing_running_test() ->
     ?assertEqual(ok, ocibuild_registry:stop_httpc()).
@@ -60,9 +64,10 @@ stop_httpc_kills_orphaned_processes_test() ->
     register(httpc_ocibuild_orphan2, Orphan2),
     ?assert(is_process_alive(Orphan1)),
     ?assert(is_process_alive(Orphan2)),
+    Ref1 = erlang:monitor(process, Orphan1),
+    Ref2 = erlang:monitor(process, Orphan2),
     ocibuild_registry:stop_httpc(),
-    timer:sleep(10),
-    ?assertNot(is_process_alive(Orphan1)),
-    ?assertNot(is_process_alive(Orphan2)),
+    receive {'DOWN', Ref1, process, Orphan1, _} -> ok after 1000 -> error(timeout) end,
+    receive {'DOWN', Ref2, process, Orphan2, _} -> ok after 1000 -> error(timeout) end,
     ?assertEqual(undefined, whereis(httpc_ocibuild_orphan1)),
     ?assertEqual(undefined, whereis(httpc_ocibuild_orphan2)).


### PR DESCRIPTION
## Summary

- Replace `ssl:stop()` in `stop_httpc/0` with `cleanup_orphaned_httpc/0` that kills only processes registered with the `httpc_ocibuild_*` prefix
- Safe for embedding: does not stop SSL, crypto, or any other shared OTP applications
- Fixes CI hang on OTP 28+ where `init:stop()` waits for all processes, and standalone httpc processes (outside supervision trees) block shutdown indefinitely

Supersedes the approach in #52 which called `ssl:stop()`, breaking library consumers that depend on SSL.

## Test plan

- [x] Existing test renamed to verify SSL is NOT stopped after `stop_httpc()`
- [x] New test verifies orphaned `httpc_ocibuild_*` processes are killed
- [x] 750 Erlang tests pass, 0 failures
- [x] 133 Elixir tests pass
- [x] Formatting clean (`rebar3 fmt --check`)